### PR TITLE
BE: Cookie Management and Logout Route

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ ___
 
 ### API
 #### Endpoints
-- `/auth/register`
- - Parameters: _name, email, password_
-- `/auth/login`
- - Parameters: _email, password_
+- `POST /auth/register`
+- `POST /auth/login`
+- `DELETE /auth/logout`
 
 #### Protecting Endpoints
 To make a certain API endpint only accessible by logged-in users, do the following:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,33 @@
 # Poll App. Hatchways Project
 
-## Server Setup
-1. Run "yarn install" or "npm install" to install all node modules needed for the app to run
+## Frontend
+
+___
+
+## Backend
+### Server
+#### Setup
+1. Run `yarn install` to install all node modules needed for the app to run
 2. Make sure MongoDB is setup and running on your localhost on port 27017. The app will connect to "poll" database on your local mongo connection.
-3. Run "yarn dev" or "npm run dev" to connect to server on "localhost:3001"
+3. Run `yarn dev` to connect to server on `localhost:3001`
+
+### API
+#### Endpoints
+- `/auth/register`
+ - Parameters: _name, email, password_
+- `/auth/login`
+ - Parameters: _email, password_
+
+#### Protecting Endpoints
+To make a certain API endpint only accessible by logged-in users, do the following:
+1. Navigate to route file
+2. Import `passport` package
+3. Add `passport.authenticate('jwt', { session: false })` as the second parameter in `router` function. For example:
+```JavaScript
+router.get("/welcome",
+  passport.authenticate('jwt', { session: false }),
+  function(req, res, next) {
+    ...
+  }
+);
+```

--- a/server/app.js
+++ b/server/app.js
@@ -9,6 +9,7 @@ const indexRouter = require("./routes/index");
 const pingRouter = require("./routes/ping");
 const registerRouter = require("./routes/auth/register.route");
 const loginRouter = require("./routes/auth/login.route");
+const logoutRouter = require("./routes/auth/logout.route");
 
 const { json, urlencoded } = express;
 
@@ -39,6 +40,7 @@ app.use("/", indexRouter);
 app.use("/ping", pingRouter);
 app.use("/auth/register", registerRouter);
 app.use("/auth/login", loginRouter);
+app.use("/auth/logout", logoutRouter);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -4,6 +4,9 @@ const mongoose = require("mongoose");
 const User = mongoose.model("users");
 const keys = require("../config/keys");
 
+// @fileDesc: Middleware that checks if user is logged in 
+  // through JWT in cookie
+
 const opts = {};
 opts.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken();
 opts.secretOrKey = keys.secretOrKey;

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -1,17 +1,28 @@
 const JwtStrategy = require("passport-jwt").Strategy;
-const ExtractJwt = require("passport-jwt").ExtractJwt;
 const mongoose = require("mongoose");
 const User = mongoose.model("users");
 const keys = require("../config/keys");
 
 // @fileDesc: Middleware that checks if user is logged in 
-  // through JWT in cookie
+  // through JWT in cookies
 
-const opts = {};
-opts.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken();
-opts.secretOrKey = keys.secretOrKey;
-
+function extractJwtFromCookies() {
+  return (req) => {
+    let token;
+  
+    if (req && req.cookies) {
+      token = req.cookies['jwt'];
+    }
+  
+    return token;
+  }
+}
+  
 module.exports = passport => {
+  const opts = {};
+  opts.jwtFromRequest = extractJwtFromCookies();
+  opts.secretOrKey = keys.secretOrKey;
+
   passport.use(
     new JwtStrategy(opts, (jwt_payload, done) => {
       User.findById(jwt_payload.id)

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -48,9 +48,7 @@ UserSchema.methods.signJWT = function (payload) {
   return jwt.sign(
     payload,
     keys.secretOrKey,
-    {
-      expiresIn: 31556926, // 1 year in seconds
-    }
+    { expiresIn: 31556926 } // 1 year in seconds
   );
 };
 

--- a/server/routes/auth/login.route.js
+++ b/server/routes/auth/login.route.js
@@ -35,9 +35,14 @@ router.post("/", (req, res) => {
       };
 
       const token = user.signJWT(payload);
-      return res.json({
-        success: true
-      })
+      res
+      .cookie("jwt", token, { httpOnly: true, secure: true })
+      .json({
+        success: true,
+        data: {
+          user
+        }
+      });
     } else {
       return res.status(400).json({ message: "Incorrect credentials" });
     }

--- a/server/routes/auth/login.route.js
+++ b/server/routes/auth/login.route.js
@@ -5,9 +5,9 @@ const validateLoginInput = require("../../validation/auth/login.validation");
 
 const User = require("../../models/User");
 
-// @route POST /auth/login
-// @desc Login user and return JWT token in cookie, and user in json response
-// @access Public
+// @route:  POST /auth/login
+// @desc:   Login user and return response that has cookie, and json user
+// @access: Public
 router.post("/", (req, res) => {
   // Form validation
   const { errors, isValid } = validateLoginInput(req.body);

--- a/server/routes/auth/login.route.js
+++ b/server/routes/auth/login.route.js
@@ -6,7 +6,7 @@ const validateLoginInput = require("../../validation/auth/login.validation");
 const User = require("../../models/User");
 
 // @route POST /auth/login
-// @desc Login user and return JWT token
+// @desc Login user and return JWT token in cookie, and user in json response
 // @access Public
 router.post("/", (req, res) => {
   // Form validation
@@ -37,12 +37,7 @@ router.post("/", (req, res) => {
       const token = user.signJWT(payload);
       res
       .cookie("jwt", token, { httpOnly: true, secure: true })
-      .json({
-        success: true,
-        data: {
-          user
-        }
-      });
+      .json({ user });
     } else {
       return res.status(400).json({ message: "Incorrect credentials" });
     }

--- a/server/routes/auth/login.route.js
+++ b/server/routes/auth/login.route.js
@@ -20,26 +20,21 @@ router.post("/", (req, res) => {
   const email = req.body.email;
   const password = req.body.password;
 
-  // Find user by email
   User.findOne({ email }).then((user) => {
-    // Check if user exists
     if (!user) {
       return res.status(400).json({ message: "Incorrect credentials" });
     }
 
-    // Check password
     const isMatch = user.checkPassword(password);
     if (isMatch) {
-      const payload = {
-        id: user.id,
-      };
-
+      const payload = { id: user.id };
       const token = user.signJWT(payload);
-      res
-      .cookie("jwt", token, { httpOnly: true, secure: true })
-      .json({ user });
+
+      user.password = null;
+
+      res.cookie("jwt", token, { httpOnly: true, secure: true }).json(user);
     } else {
-      return res.status(400).json({ message: "Incorrect credentials" });
+      res.status(400).json({ message: "Incorrect credentials" });
     }
   });
 });

--- a/server/routes/auth/logout.route.js
+++ b/server/routes/auth/logout.route.js
@@ -1,0 +1,19 @@
+const express = require("express");
+const passport = require("passport");
+const router = express.Router();
+
+// @route:  DELETE /auth/logout
+// @desc:   Logout user and delete jwt from request cookies
+// @access: Private
+router.delete("/",
+  passport.authenticate('jwt', { session: false }),
+  (req, res) => {
+    // We know that jwt is in cookies since this is a protected route
+      // (a check happens through passport)
+    res.clearCookie('jwt');
+
+    return res.json({ success: true })
+  }
+);
+
+module.exports = router;

--- a/server/routes/auth/register.route.js
+++ b/server/routes/auth/register.route.js
@@ -16,15 +16,15 @@ router.post("/", (req, res) => {
     return res.status(400).json(errors);
   }
 
-  User.findOne({ email: req.body.email }).then(user => {
+  const name = req.body.name;
+  const email = req.body.email;
+  const password = req.body.password; 
+
+  User.findOne({ email }).then(user => {
     if (user) {
       return res.status(400).json({ email: "Email already exists" });
     } else {
-      const newUser = new User({
-        name: req.body.name,
-        email: req.body.email,
-        password: req.body.password
-      });
+      const newUser = new User({ name, email, password });
       
       newUser.save()
         .then(user => {

--- a/server/routes/auth/register.route.js
+++ b/server/routes/auth/register.route.js
@@ -28,8 +28,12 @@ router.post("/", (req, res) => {
       
       newUser.save()
         .then(user => {
+          const payload = { id: user.id };
+          const token = user.signJWT(payload);
+
           user.password = null;
-          res.json(user);
+          
+          res.cookie("jwt", token, { httpOnly: true, secure: true }).json(user);
         })
         .catch(err => console.log(err));
     }

--- a/server/routes/auth/register.route.js
+++ b/server/routes/auth/register.route.js
@@ -28,8 +28,8 @@ router.post("/", (req, res) => {
       
       newUser.save()
         .then(user => {
-          delete user.password; // remove hashed password from response
-          return res.json(user);
+          user.password = null;
+          res.json(user);
         })
         .catch(err => console.log(err));
     }

--- a/server/routes/auth/register.route.js
+++ b/server/routes/auth/register.route.js
@@ -4,9 +4,9 @@ const router = express.Router();
 const validateRegisterInput = require("../../validation/auth/register.validation");
 const User = require("../../models/User");
 
-// @route POST /auth/register
-// @desc Register user
-// @access Public
+// @route:  POST /auth/register
+// @desc:   Register user and return response that has cookie, and json user
+// @access: Public
 router.post("/", (req, res) => {
   // Form validation
   const { errors, isValid } = validateRegisterInput(req.body);


### PR DESCRIPTION
In this pull request, I:
- Made the JWT token get stored in cookies
- Created `/auth/logout` route
- Updated `README.md` with 
  - API endpoints
  - Instructions on how to protect routes (how to make only logged-in users able to access them)

#### How to test
1. Login
  1.1. Ref [this PR](https://github.com/hatchways/team-eagle/pull/11) on how to login through Postman
2. Go to Postman [cookie manager](https://learning.postman.com/docs/postman/sending-api-requests/cookies/) and make sure that you have a `jwt` cookie under `localhost`
3. Copy the cookie
4. Paste it in `Headers` under the key of `Cookie`
5. Make a `DELETE` request to `/auth/logout`
You should get this:
```
{ success: true }
```
6. Remove the cookie from `Headers` and make the same request again
You should get this:
```
Unauthorized
```

The same process could be done to test `/auth/register`


Thanks,
H


