### PR TITLE
BE/FE: Get User Route + Stay Logged-In

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,18 @@ The upload functions will take the credentials from your local .env file. Please
 
 #### Endpoints
 
-Login Routes
+User Routes
+
+- `GET /users/current`
+
+Auth Routes
 
 - `POST /auth/register`
 - `POST /auth/login`
 - `DELETE /auth/logout`
+
   Polls Routes
+
 - `POST /polls`
 - `PUT /polls/<pollId>`
 - `DELETE /polls/<pollId>`

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,7 +7,6 @@ import { UserContext } from './components/UserContext';
 
 import NavBar from './components/NavBar';
 import LandingPage from './pages/Landing/Landing';
-import FriendsIndex from './pages/Friends/components/FriendsIndex';
 
 import './App.css';
 
@@ -16,6 +15,7 @@ function App() {
 
   React.useEffect(() => {
     // Verify if the user is validated and if so, setUser
+    if (!user._id) user.getCurrent();
   });
 
   return (

--- a/client/src/components/UserContext.js
+++ b/client/src/components/UserContext.js
@@ -7,8 +7,6 @@ export const UserContext = React.createContext();
 export const ContextProvider = ({ children }) => {
   const [state, setState] = React.useState({});
 
-  debugger;
-
   function getCurrent(callback) {
     fetch('/users/current', {
       method: 'GET',

--- a/client/src/components/UserContext.js
+++ b/client/src/components/UserContext.js
@@ -7,6 +7,28 @@ export const UserContext = React.createContext();
 export const ContextProvider = ({ children }) => {
   const [state, setState] = React.useState({});
 
+  debugger;
+
+  function getCurrent(callback) {
+    fetch('/users/current', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }).then((res) => {
+      res.json().then((data) => {
+        if (res.status === 200) {
+          setState({
+            ...state,
+            ...data,
+          });
+        } else if (callback) {
+          callback(res.status);
+        }
+      });
+    });
+  }
+
   function signup(payload, callback) {
     fetch('/auth/register', {
       method: 'POST',
@@ -61,7 +83,9 @@ export const ContextProvider = ({ children }) => {
   }
 
   return (
-    <UserContext.Provider value={{ ...state, signup, login, logout }}>
+    <UserContext.Provider
+      value={{ ...state, getCurrent, signup, login, logout }}
+    >
       {children}
     </UserContext.Provider>
   );

--- a/server/app.js
+++ b/server/app.js
@@ -6,11 +6,13 @@ const logger = require('morgan');
 const passport = require('passport');
 const cors = require('cors');
 
+// Users routes
+const usersRouter = require('./routes/users/users.route');
 // Auth routes
 const authRouter = require('./routes/auth/auth.route');
 // Poll routes
 const pollsRouter = require('./routes/polls/polls.route');
-// Friends Routes
+// Friends routes
 const friendsRouter = require('./routes/users/friends/friends.route');
 
 const { json, urlencoded } = express;
@@ -41,8 +43,8 @@ app.use(passport.initialize());
 // Passport config
 require('./config/passport')(passport);
 
-// Routes
-
+// Users Routes
+app.use('/users', usersRouter);
 // Auth Routes
 app.use('/auth', authRouter);
 // Poll Routes

--- a/server/routes/auth/auth.route.js
+++ b/server/routes/auth/auth.route.js
@@ -34,10 +34,17 @@ router.post('/register', (req, res) => {
         .then((user) => {
           const payload = { id: user.id };
           const token = user.signJWT(payload);
+          const options = {
+            httpOnly: true,
+          };
+
+          if (process.env.NODE_ENV === 'production') {
+            options.secure = true; // Only send cookies with https protocol
+          }
 
           user.password = null;
 
-          res.cookie('jwt', token, { httpOnly: true, secure: true }).json(user);
+          res.cookie('jwt', token, options).json(user);
         })
         .catch((err) => console.log(err));
     }
@@ -68,10 +75,17 @@ router.post('/login', (req, res) => {
     if (isMatch) {
       const payload = { id: user.id };
       const token = user.signJWT(payload);
+      const options = {
+        httpOnly: true,
+      };
+
+      if (process.env.NODE_ENV === 'production') {
+        options.secure = true; // Only send cookies with https protocol
+      }
 
       user.password = null;
 
-      res.cookie('jwt', token, { httpOnly: true, secure: true }).json(user);
+      res.cookie('jwt', token, options).json(user);
     } else {
       res.status(400).json({ message: 'Incorrect credentials' });
     }

--- a/server/routes/auth/auth.route.js
+++ b/server/routes/auth/auth.route.js
@@ -32,7 +32,7 @@ router.post('/register', (req, res) => {
       newUser
         .save()
         .then((user) => {
-          const payload = { id: user.id };
+          const payload = { id: user._id };
           const token = user.signJWT(payload);
           const options = {
             httpOnly: true,

--- a/server/routes/users/users.route.js
+++ b/server/routes/users/users.route.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const passport = require('passport');
+const router = express.Router({ mergeParams: true });
+
+// @route:  GET /users/current
+// @desc:   Find current logged in user and return it
+// @access: Private
+router.get(
+  '/current',
+  passport.authenticate('jwt', { session: false }),
+  async (req, res) => {
+    const currUser = req.user;
+
+    res.json(currUser);
+  }
+);
+
+module.exports = router;

--- a/server/test/users/user.spec.js
+++ b/server/test/users/user.spec.js
@@ -9,45 +9,30 @@ const expect = chai.expect;
 
 describe('GET /users/current', () => {
   context('When user is logged in', () => {
-    beforeEach((done) => {
+    before(async () => {
       let user = {
         email: 'seedEmail1@gmail.com',
         password: '12345678',
       };
 
-      chai
-        .request(app)
-        .post('/auth/login')
-        .send(user)
-        .end((err, res) => {
-          this.response = res;
-          this.cookie = this.response.headers['set-cookie'].find((el) =>
-            el.includes('jwt=')
-          );
-          done();
-        });
-    });
+      const loginRes = await chai.request(app).post('/auth/login').send(user);
 
-    it('it returns 200 status code', (done) => {
-      chai
+      this.cookie = loginRes.headers['set-cookie'].find((el) =>
+        el.includes('jwt=')
+      );
+
+      this.response = await chai
         .request(app)
         .get('/users/current')
-        .set('Cookie', this.cookie)
-        .end((err, res) => {
-          res.should.have.status(200);
-          done();
-        });
+        .set('Cookie', this.cookie);
     });
 
-    it('it returns an instance of the logged in user', (done) => {
-      chai
-        .request(app)
-        .get('/users/current')
-        .set('Cookie', this.cookie)
-        .end((err, res) => {
-          expect(res._id).to.be.a('string');
-          done();
-        });
+    it('it returns 200 status code', () => {
+      this.response.should.have.status(200);
+    });
+
+    it('it returns an instance of the logged in user', () => {
+      expect(this.response.body._id).to.be.a('string');
     });
   });
 

--- a/server/test/users/user.spec.js
+++ b/server/test/users/user.spec.js
@@ -1,0 +1,76 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const app = require('../../app.js');
+
+chai.should();
+chai.use(chaiHttp);
+
+const expect = chai.expect;
+
+describe('GET /users/current', () => {
+  context('When user is logged in', () => {
+    beforeEach((done) => {
+      let user = {
+        email: 'seedEmail1@gmail.com',
+        password: '12345678',
+      };
+
+      chai
+        .request(app)
+        .post('/auth/login')
+        .send(user)
+        .end((err, res) => {
+          this.response = res;
+          this.cookie = this.response.headers['set-cookie'].find((el) =>
+            el.includes('jwt=')
+          );
+          done();
+        });
+    });
+
+    it('it returns 200 status code', (done) => {
+      chai
+        .request(app)
+        .get('/users/current')
+        .set('Cookie', this.cookie)
+        .end((err, res) => {
+          res.should.have.status(200);
+          done();
+        });
+    });
+
+    it('it returns an instance of the logged in user', (done) => {
+      chai
+        .request(app)
+        .get('/users/current')
+        .set('Cookie', this.cookie)
+        .end((err, res) => {
+          expect(res._id).to.be.a('string');
+          done();
+        });
+    });
+  });
+
+  context('When user is logged out', () => {
+    before((done) => {
+      chai
+        .request(app)
+        .delete('/auth/logout')
+        .set('Cookie', this.cookie)
+        .end((err, res) => {
+          this.response = res;
+          done();
+        });
+    });
+
+    it('it returns 401 status code', (done) => {
+      chai
+        .request(app)
+        .get('/users/current')
+        .end((err, res) => {
+          res.should.have.status(401);
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
In this pull request, I:
- Created an API route for getting the current logged in user
  - `GET /users/current`
- Fetched logged in user on mount of `App` (frontend) and automatically authenticated them if they had a valid `jwt`

### How to test
#### Frontend:
1. Log in or register
2. Close tab or browser
3. Go back to app
4. Check that you are still logged in

You should stay logged in

#### Backend:
- `yarn test`

All tests should pass