### PR TITLE
BE : More DRY Login/Register Code

### DIFF
--- a/server/models/user.js
+++ b/server/models/user.js
@@ -73,4 +73,23 @@ UserSchema.methods.makeDisactive = function () {
   this.save();
 };
 
+UserSchema.methods.loginRegisterClientResponse = function () {
+  const payload = { id: this._id };
+  const token = this.signJWT(payload);
+  const options = {
+    httpOnly: true,
+  };
+
+  if (process.env.NODE_ENV === 'production') {
+    options.secure = true; // Only send cookies with https protocol
+  }
+
+  this.password = null;
+
+  return {
+    token,
+    options,
+  };
+};
+
 module.exports = User = mongoose.model('users', UserSchema);

--- a/server/routes/auth/auth.route.js
+++ b/server/routes/auth/auth.route.js
@@ -32,17 +32,7 @@ router.post('/register', (req, res) => {
       newUser
         .save()
         .then((user) => {
-          const payload = { id: user._id };
-          const token = user.signJWT(payload);
-          const options = {
-            httpOnly: true,
-          };
-
-          if (process.env.NODE_ENV === 'production') {
-            options.secure = true; // Only send cookies with https protocol
-          }
-
-          user.password = null;
+          const { token, options } = user.loginRegisterClientResponse();
 
           res.cookie('jwt', token, options).json(user);
         })
@@ -73,17 +63,7 @@ router.post('/login', (req, res) => {
 
     const isMatch = user.checkPassword(password);
     if (isMatch) {
-      const payload = { id: user._id };
-      const token = user.signJWT(payload);
-      const options = {
-        httpOnly: false,
-      };
-
-      if (process.env.NODE_ENV === 'production') {
-        options.secure = true; // Only send cookies with https protocol
-      }
-
-      user.password = null;
+      const { token, options } = user.loginRegisterClientResponse();
 
       res.cookie('jwt', token, options).json(user);
     } else {

--- a/server/routes/auth/auth.route.js
+++ b/server/routes/auth/auth.route.js
@@ -73,7 +73,7 @@ router.post('/login', (req, res) => {
 
     const isMatch = user.checkPassword(password);
     if (isMatch) {
-      const payload = { id: user.id };
+      const payload = { id: user._id };
       const token = user.signJWT(payload);
       const options = {
         httpOnly: false,

--- a/server/routes/polls/polls.route.js
+++ b/server/routes/polls/polls.route.js
@@ -52,7 +52,7 @@ router.delete(
     const pollId = req.params['pollId'];
     Poll.findById(pollId, function (err, poll) {
       if (err) return res.status(400).json({ error: 'poll not found' });
-      else if (poll._id != req.user.id)
+      else if (poll._id != req.user._id)
         return res.status(400).json({ error: 'unauthorised deletion' });
       poll.remove();
       return res.status(200).json({ status: 'ok' });
@@ -76,7 +76,7 @@ router.put(
     Poll.findById(pollId, (err, poll) => {
       if (err) return console.log(err);
       // Update the title if the title exists
-      else if (poll.userId != req.user.id)
+      else if (poll.userId != req.user._id)
         return res.status(400).json({ error: 'unauthorised deletion' });
       if (req.body.title) {
         if (req.body.title != poll.title) {


### PR DESCRIPTION
In this PR, I:
- Refactored JSON response code in `/auth/login` and `/auth/register` routes to more closely follow DRY principles
- Fixed `user.id` potential mistyping to be `user._id` 

Fixes #30 